### PR TITLE
fix: only search index.html if exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,11 @@ function VitePluginWindicss(options: UserOptions = {}): Plugin[] {
             absolute: true,
           },
         )
-
-        files.unshift(join(viteConfig.root, 'index.html'))
+        
+        const index = join(viteConfig.root, 'index.html')
+        if (existsSync(index)) {
+          files.unshift(index)
+        }
 
         debug.glob('files', files)
 


### PR DESCRIPTION
Otherwise it errors in a VitePress project where `index.html` is served virtually.