### PR TITLE
fix: conditional CSS in Vue templates, close #7

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-teal-100 px-5 p-1">
+  <div class="px-5 p-1 text-white hover:text-green-100" :class="{ 'bg-teal-100': true, 'hover:w-1/3': true }">
     Hello World
   </div>
   <h2 class="button">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 export const MODULE_ID = 'windi.css'
 export const MODULE_ID_VIRTUAL = `/@windicss/${MODULE_ID}`
 
-export const regexQuotedString = /(["'`])([^"'`<>,\n]+?)\1/g
+export const regexQuotedString = /(["'`])((?:\\\1|(?:(?!\1)).)*?)\1/g
 export const regexClassCheck = /^[a-z-]+[a-z0-9:\-/\\]*\.?[a-z0-9]$/
 export const regexHtmlTag = /<([\w-]+)/g
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 export const MODULE_ID = 'windi.css'
 export const MODULE_ID_VIRTUAL = `/@windicss/${MODULE_ID}`
 
-export const regexQuotedString = /(["'`])([^"'`<>,]+?)\1/g
+export const regexQuotedString = /(["'`])((?:\\\1|(?:(?!\1)).)*?)\1/g
 export const regexClassCheck = /^[a-z-]+[a-z0-9:\-/\\]*\.?[a-z0-9]$/
 export const regexHtmlTag = /<([\w-]+)/g
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 export const MODULE_ID = 'windi.css'
 export const MODULE_ID_VIRTUAL = `/@windicss/${MODULE_ID}`
 
-export const regexQuotedString = /(["'`])((?:\\\1|(?:(?!\1)).)*?)\1/g
+export const regexQuotedString = /(["'`])([^"'`<>,]+?)\1/g
 export const regexClassCheck = /^[a-z-]+[a-z0-9:\-/\\]*\.?[a-z0-9]$/
 export const regexHtmlTag = /<([\w-]+)/g
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 export const MODULE_ID = 'windi.css'
 export const MODULE_ID_VIRTUAL = `/@windicss/${MODULE_ID}`
 
-export const regexQuotedString = /(["'`])((?:\\\1|(?:(?!\1)).)*?)\1/g
+export const regexQuotedString = /(["'`])([^"'`<>,\n]+?)\1/g
 export const regexClassCheck = /^[a-z-]+[a-z0-9:\-/\\]*\.?[a-z0-9]$/
 export const regexHtmlTag = /<([\w-]+)/g
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function VitePluginWindicss(options: UserOptions = {}): Plugin[] {
             absolute: true,
           },
         )
-        
+
         const index = join(viteConfig.root, 'index.html')
         if (existsSync(index)) {
           files.unshift(index)

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,8 @@ function VitePluginWindicss(options: UserOptions = {}): Plugin[] {
         )
 
         const index = join(viteConfig.root, 'index.html')
-        if (existsSync(index)) {
+        if (existsSync(index))
           files.unshift(index)
-        }
 
         debug.glob('files', files)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ function VitePluginWindicss(options: UserOptions = {}): Plugin[] {
     debug.detect(id)
     // classes
     Array.from(code.matchAll(regexQuotedString))
-      .flatMap(m => m[2]?.split(' ') || [])
+      .flatMap(m => m[2]?.split(/[\s'"`{}]/g) || [])
       .filter(i => i.match(regexClassCheck))
       .forEach((i) => {
         if (!i || classes.has(i))


### PR DESCRIPTION
### Description 📖 

This pull request fixes the scanner so that it can parse conditional CSS rules in Vue templates.

Checked on the example and in one of my projects, but since regexes are tricky and this one has had many iterations, would like @antfu to review it before merging.

### Notes ✏️ 

Using ```[^"'`<>,]``` is a simple way to avoid all terminators, and any partial matches on HTML tags.

Using `+?` makes the match non-greedy, which means it will stop as soon as it finds the first opening `\1`.