### PR TITLE
Ensure the library is built before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "example:build": "npm -C example run build",
     "build": "tsup src/index.ts --dts --format cjs,esm",
     "prepublishOnly": "npm run build",
-    "release": "npx bumpp --commit --tag --push && npm publish"
+    "release": "npm run build && npx bumpp --commit --tag --push && npm publish"
   },
   "dependencies": {
     "fast-glob": "^3.2.5",


### PR DESCRIPTION
### Description 📖 

Open to discussion, but I think it's always a good idea to build before publish.

That way we prevent, emm, what I did after merging https://github.com/windicss/vite-plugin-windicss/pull/8 😅 