### PR TITLE
fix: class check regex to accept variants starting with numbers and "+"

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -1,5 +1,5 @@
 export const regexQuotedString = /(["'`])((?:\\\1|(?:(?!\1)|\n).)*?)\1/mg
-export const regexClassCheck = /^[a-z.-]+[\w:/\\.$-]*\w$/
+export const regexClassCheck = /^[a-z\d.+-]+[\w:/\\.$-]*\w$/
 export const regexHtmlTag = /<(\w[\w-]*)/g
 export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /(\w[\w:_/-]*?):\(([\w\s/-]*?)\)/gm


### PR DESCRIPTION
this enables selectors like:
2xl:text-xl
or
+lg:bg-red-900