### PR TITLE
feat: Allow users to provide a custom root to resolve files against

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -25,6 +25,7 @@ export function createUtils(
     transformCSS: enableCssTransform,
     preflight: enablePreflight,
     preflightOptions,
+    root = utilsOptions.root || process.cwd(),
     sortUtilities,
     safelist,
     blocklist,
@@ -32,7 +33,6 @@ export function createUtils(
 
   const {
     name = 'windicss-plugin-utils',
-    root = process.cwd(),
     enabledTypeScriptConfig = true,
   } = utilsOptions
 

--- a/packages/plugin-utils/src/options.ts
+++ b/packages/plugin-utils/src/options.ts
@@ -69,6 +69,14 @@ export interface UserOptions {
   }
 
   /**
+    * File paths will be resolved against this directory.
+    *
+    * @default process.cwd
+    * @internal
+    */
+  root?: string
+
+  /**
    * Scan the files and extract the usage
    *
    * @default true
@@ -196,6 +204,7 @@ export interface ResolvedOptions {
     blocklist: Set<string>
     alias: Record<string, TagNames>
   }
+  root: string
   transformCSS: boolean | 'pre' | 'auto' | 'post'
   transformGroups: boolean
   sortUtilities: boolean


### PR DESCRIPTION
### Description 📖 

This pull request adds `root` as a user option.

When provided, it takes precedence over Vite's config `root`.

When not provided, the behavior remains unchanged, so this can be released in a `patch` version.

### Background 📜 

In [projects](https://github.com/ElMassimo/pingcrm-vite) where Vite's root is not the project root, it can be preferable for files and dirs provided in the configuration options to be [resolved](https://github.com/ElMassimo/pingcrm-vite/blob/main/vite.config.ts#L16-L19) against the project root instead of Vite's root.

### Comparison

#### Before

Files and dirs needed to be resolved manually:

```js
const resolve = (file) => path.resolve(process.cwd(), file)

export default defineConfig({
  plugins: [
    WindiCSS({
      config: resolve('windi.config.ts'),
      scan: {
        dirs: ['app/views', 'app/helpers', 'app/javascript'].map(resolve),
      },
    }),
	...
```

#### After

Providing the root allows files and dirs to be resolved to be resolved against it:

```js
export default defineConfig({
  plugins: [
    WindiCSS({
      root: process.cwd(),
      scan: {
        dirs: ['app/views', 'app/helpers', 'app/javascript'],
      },
    }),
	...
```

Notice that the `config` option is no longer necessary, as the defaults are now resolved using the provided `root`.