### PR TITLE
fix(pug): invalid pug breaking builds

### DIFF
--- a/examples/vue-pug/src/App.vue
+++ b/examples/vue-pug/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang='ts'>
 import Foo from './Foo.vue'
+import InvalidPug from './InvalidPug.vue'
 </script>
 
 <template lang="pug">
@@ -9,6 +10,7 @@ div
   h2.btn Button
   .bar Bar
   Foo
+  InvalidPug
   router-link
   .bg-black.bg-blue-200.bg-red-200 Without ! (red)
   .bg-black.bg-red-200(class="!bg-blue-200")

--- a/examples/vue-pug/src/InvalidPug.vue
+++ b/examples/vue-pug/src/InvalidPug.vue
@@ -1,0 +1,4 @@
+<template lang="pug">
+      .pl-25px
+               .bg-yellow-500 This is not valid
+</template>

--- a/packages/plugin-utils/src/transformers/pug.ts
+++ b/packages/plugin-utils/src/transformers/pug.ts
@@ -11,13 +11,14 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const Pug = require('pug') as typeof import('pug')
 
-  const compile = (code : string) => {
+  const compile = (code: string) => {
     try {
       return Pug.compile(code, { filename: id })()
       // other build processes will catch pug errors
-    } catch (e) {}
-    return
+    }
+    catch {}
   }
+
   if (id.match(/\.vue$/)) {
     const matches = Array.from(code.matchAll(regexTemplate))
     let tail = ''
@@ -27,7 +28,8 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
     }
     if (tail)
       return `${code}\n\n${tail}`
-  } else {
+  }
+  else {
     return compile(code)
   }
 }

--- a/packages/plugin-utils/src/transformers/pug.ts
+++ b/packages/plugin-utils/src/transformers/pug.ts
@@ -11,7 +11,7 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const Pug = require('pug') as typeof import('pug')
 
-  const render = (code : string) => {
+  const compile = (code : string) => {
     try {
       return Pug.compile(code, { filename: id })()
       // other build processes will catch pug errors
@@ -23,11 +23,11 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
     let tail = ''
     for (const match of matches) {
       if (match && match[1])
-        tail += `\n\n${render(match[1])}`
+        tail += `\n\n${compile(match[1])}`
     }
     if (tail)
       return `${code}\n\n${tail}`
   } else {
-    return render(code)
+    return compile(code)
   }
 }

--- a/packages/plugin-utils/src/transformers/pug.ts
+++ b/packages/plugin-utils/src/transformers/pug.ts
@@ -13,8 +13,7 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
 
   const render = (code : string) => {
     try {
-      // render with caching enabled
-      return Pug.compile(code)()
+      return Pug.compile(code, { filename: id })()
       // other build processes will catch pug errors
     } catch (e) {}
     return

--- a/packages/plugin-utils/src/transformers/pug.ts
+++ b/packages/plugin-utils/src/transformers/pug.ts
@@ -11,17 +11,24 @@ export const PugTransformer: Transformer<TransformerOptions> = ({
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const Pug = require('pug') as typeof import('pug')
 
+  const render = (code : string) => {
+    try {
+      // render with caching enabled
+      return Pug.compile(code)()
+      // other build processes will catch pug errors
+    } catch (e) {}
+    return
+  }
   if (id.match(/\.vue$/)) {
     const matches = Array.from(code.matchAll(regexTemplate))
     let tail = ''
     for (const match of matches) {
       if (match && match[1])
-        tail += `\n\n${Pug.compile(match[1])()}`
+        tail += `\n\n${render(match[1])}`
     }
     if (tail)
       return `${code}\n\n${tail}`
-  }
-  else {
-    return Pug.compile(code)()
+  } else {
+    return render(code)
   }
 }


### PR DESCRIPTION
Previously if there was invalid pug code, the exception would be pushed up to the compiler when windy is initialised. For the windi init to handle this exception is a bit redundant as the rest of the build process will also pick them up. 

Instead, we can just ignore invalid pug files and let them bubble up elsewhere. This is similar to how runtime component imports work.
