### PR TITLE
feat: Allow re-scanning files after changes by watching them in Vite.

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -379,6 +379,7 @@ export function createUtils(
     init,
     extractFile,
     generateCSS,
+    getFiles,
     clearCache,
     transformCSS,
     transformGroups,

--- a/packages/vite-plugin-windicss/src/index.ts
+++ b/packages/vite-plugin-windicss/src/index.ts
@@ -74,9 +74,14 @@ function VitePluginWindicss(userOptions: UserOptions = {}): Plugin[] {
     apply: 'serve',
     enforce: 'post',
 
-    configureServer(server) {
+    async configureServer(server) {
       if (utils.configFilePath)
         server.watcher.add(utils.configFilePath)
+
+      // NOTE: Track changes to the files so that they are re-scanned as needed.
+      // Added files are only detected if the user explicitly enables globbing.
+      const supportsGlobs = server.config.server.watch?.disableGlobbing === false
+      server.watcher.add(supportsGlobs ? utils.globs : await utils.getFiles())
     },
 
     async handleHotUpdate({ server, file, read, modules }) {


### PR DESCRIPTION
### Description 📖 

This pull request adds the scanned files to Vite's dev server watcher, allowing changes to these files to trigger a re-evaluation of the Windi CSS styles.

This enables the plugin to detect new Windi CSS classes when making changes to server-side templates.

To minimize the impact of this feature, only matching files at startup will be watched. In order to detect added files, a user should manually enable globbing in Vite's file watcher:

```js
server: {
  watch: {
    disableGlobbing: false,
  },
},
```

### Background 📜

When using Vite in combination with a backend server, where some of the templates are rendered server-side, a typical configuration might look like:

```js
    WindiCSS({
      root: process.cwd(),
      scan: {
        fileExtensions: ['erb', 'html', 'vue', 'rb', 'jsx', 'tsx'],
        dirs: ['app/views'],
      },
    }),
``` 

Any styles used in the templates will be picked up during the __initial scan__ that runs on startup.

However, if they are not watched adding classes to them won't trigger the `handleHotReload` hook, so CSS for those utilities __won't be injected__.

### References 🔗

- [Discussion about adding styles to server-rendered templates](https://github.com/ElMassimo/vite_ruby/discussions/37#discussioncomment-505588)