### PR TITLE
feat(hooks): add onOptionsResolved & onConfigResolved hooks

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -118,10 +118,9 @@ export function createUtils(
     }
 
     // allow to hook into resolved config
-    if (typeof options.onConfigResolved === 'function') {
-      // @ts-ignore
-      options.onConfigResolved({ configFilePath, config: resolved })
-    }
+    const modifiedConfigs = options.onConfigResolved?.(resolved, configFilePath)
+    if (modifiedConfigs != null)
+      resolved = modifiedConfigs
 
     debug.config(JSON.stringify(resolved, null, 2))
     return resolved

--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -117,6 +117,12 @@ export function createUtils(
       resolved = config
     }
 
+    // allow to hook into resolved config
+    if (typeof options.onConfigResolved === 'function') {
+      // @ts-ignore
+      options.onConfigResolved({ configFilePath, config: resolved })
+    }
+
     debug.config(JSON.stringify(resolved, null, 2))
     return resolved
   }

--- a/packages/plugin-utils/src/options.ts
+++ b/packages/plugin-utils/src/options.ts
@@ -165,7 +165,7 @@ export interface UserOptions {
    * Callback when the windi config is resolved. Not to be confused with the options which are the top level way to
    * configure the util package
    */
-  onConfigResolved?: (ctx: { config: WindiCssOptions, configFilePath: string } ) => WindiCssOptions | void
+  onConfigResolved?: (config: WindiCssOptions, configFilePath?: string) => WindiCssOptions | void
 }
 
 export interface WindiPluginUtilsOptions {
@@ -328,9 +328,9 @@ export function resolveOptions(options: UserOptions | ResolvedOptions = {}): Res
   } as ResolvedOptions
 
   // allow the resolved options to be overwritten
-  if (typeof resolvedOptions.onOptionsResolved === 'function') {
-    resolvedOptions.onOptionsResolved(resolvedOptions)
-  }
+  const modifiedOptions = resolvedOptions.onOptionsResolved?.(resolvedOptions)
+  if (modifiedOptions != null && modifiedOptions !== resolvedOptions)
+    resolvedOptions = Object.assign(resolvedOptions, modifiedOptions)
 
   return resolvedOptions
 }

--- a/packages/plugin-utils/test/hooks.test.ts
+++ b/packages/plugin-utils/test/hooks.test.ts
@@ -1,12 +1,10 @@
-import { createUtils } from '../src'
-import {ResolvedOptions} from "../src";
+import { createUtils, ResolvedOptions } from '../src'
 
 describe('config hooks', () => {
   it('work onOptionsResolved', () => {
-
     const utils = createUtils({
       config: {},
-      onOptionsResolved: (config : ResolvedOptions) => {
+      onOptionsResolved: (config: ResolvedOptions) => {
         expect(config.safelist).toEqual(new Set<String>(['px-1', 'px-2', 'px-3', 'px-4']))
         config.safelist.add('px-5')
       },
@@ -20,12 +18,11 @@ describe('config hooks', () => {
   })
 
   it('work onOptionsResolved', () => {
-
     const utils = createUtils({
       config: {
-        prefix: 'windi-'
+        prefix: 'windi-',
       },
-      onConfigResolved: ({ config}) => {
+      onConfigResolved: (config) => {
         expect(config).toEqual({ prefix: 'windi-' })
         config.prefix = 'not-windi-'
       },
@@ -35,4 +32,21 @@ describe('config hooks', () => {
     expect(utils.processor.config('prefix')).toEqual('not-windi-')
   })
 
+  it('work onOptionsResolved to replace config', () => {
+    const utils = createUtils({
+      config: {
+        prefix: 'windi-',
+      },
+      onConfigResolved: (config) => {
+        expect(config).toEqual({ prefix: 'windi-' })
+        return {
+          darkMode: 'class',
+        }
+      },
+    })
+    utils.init()
+
+    expect(utils.processor.config('darkMode')).toEqual('class')
+    expect(utils.processor.config('prefix')).toEqual(undefined)
+  })
 })

--- a/packages/plugin-utils/test/hooks.test.ts
+++ b/packages/plugin-utils/test/hooks.test.ts
@@ -1,0 +1,38 @@
+import { createUtils } from '../src'
+import {ResolvedOptions} from "../src";
+
+describe('config hooks', () => {
+  it('work onOptionsResolved', () => {
+
+    const utils = createUtils({
+      config: {},
+      onOptionsResolved: (config : ResolvedOptions) => {
+        expect(config.safelist).toEqual(new Set<String>(['px-1', 'px-2', 'px-3', 'px-4']))
+        config.safelist.add('px-5')
+      },
+      safelist: [
+        'px-1',
+        ['px-2 px-3', 'px-4'],
+      ],
+    })
+    utils.init()
+    expect(utils.options.safelist).toEqual(new Set<String>(['px-1', 'px-2', 'px-3', 'px-4', 'px-5']))
+  })
+
+  it('work onOptionsResolved', () => {
+
+    const utils = createUtils({
+      config: {
+        prefix: 'windi-'
+      },
+      onConfigResolved: ({ config}) => {
+        expect(config).toEqual({ prefix: 'windi-' })
+        config.prefix = 'not-windi-'
+      },
+    })
+    utils.init()
+
+    expect(utils.processor.config('prefix')).toEqual('not-windi-')
+  })
+
+})


### PR DESCRIPTION
Related to: https://github.com/windicss/nuxt-windicss-module/issues/30

We need an easy way for the end-user to hook into the option & configs. 

For this to work in the nuxt repo I'll probably have to setup hooks to wrap these as the nuxt context is required to resolve the config properly.