### PR TITLE
fix: do not bundle sub exports of windicss

### DIFF
--- a/packages/plugin-utils/tsup.config.ts
+++ b/packages/plugin-utils/tsup.config.ts
@@ -1,0 +1,5 @@
+export default {
+  external: [
+    /^windicss.*/
+  ]
+}


### PR DESCRIPTION
currently only Processor is imported from node_modules but all sub exports are bundled.
this adds all windicss exports to tsup's internal rollup config
related: https://github.com/windicss/windicss/issues/199