### PR TITLE
fix: avoid crawling excluded paths

### DIFF
--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -28,16 +28,18 @@
   },
   "dependencies": {
     "debug": "^4.3.2",
-    "fast-glob": "^3.2.5",
+    "globrex": "^0.1.2",
     "magic-string": "^0.25.7",
     "micromatch": "^4.0.4",
     "pirates": "^4.0.1",
+    "recrawl": "^2.2.0",
     "sucrase": "^3.17.1",
     "windicss": "^2.5.14"
   },
   "devDependencies": {
     "@antfu/ni": "^0.5.7",
     "@types/debug": "^4.1.5",
+    "@types/globrex": "^0.1.0",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.14.37",
     "@types/pug": "^2.0.4",

--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -58,9 +58,10 @@ export function createUtils(
     debug.glob('include', options.scanOptions.include)
     debug.glob('exclude', options.scanOptions.exclude)
 
+    const root = slash(options.root)
     const compileGlob = (glob: string) => {
-      if (glob.startsWith(options.root)) {
-        glob = glob.slice(options.root.length + 1)
+      if (glob.startsWith(root)) {
+        glob = glob.slice(root.length + 1)
       }
       return globrex(glob, {
         globstar: true,
@@ -68,7 +69,7 @@ export function createUtils(
       }).regex
     }
 
-    const files = await crawl(options.root, {
+    const files = await crawl(root, {
       only: options.scanOptions.include.map(compileGlob),
       skip: options.scanOptions.exclude.map(compileGlob),
       absolute: true,

--- a/packages/plugin-utils/src/resolveOptions.ts
+++ b/packages/plugin-utils/src/resolveOptions.ts
@@ -105,7 +105,7 @@ export async function resolveOptions(
     config.extract?.exclude,
     scanOptions.exclude,
     // only set default value when exclude is not provided
-    config.extract?.exclude ? [] : ['node_modules/**/*', '.git/**/*'],
+    config.extract?.exclude ? [] : ['node_modules', '.git'],
   )
     .map(i => slash(resolve(root, i)))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,30 +155,34 @@ importers:
     specifiers:
       '@antfu/ni': ^0.5.7
       '@types/debug': ^4.1.5
+      '@types/globrex': ^0.1.0
       '@types/micromatch': ^4.0.1
       '@types/node': ^14.14.37
       '@types/pug': ^2.0.4
       debug: ^4.3.2
-      fast-glob: ^3.2.5
+      globrex: ^0.1.2
       magic-string: ^0.25.7
       micromatch: ^4.0.4
       pirates: ^4.0.1
       pug: ^3.0.2
+      recrawl: ^2.2.0
       sucrase: ^3.17.1
       tsup: ^4.8.21
       typescript: ^4.2.4
       windicss: ^2.5.14
     dependencies:
       debug: 4.3.2
-      fast-glob: 3.2.5
+      globrex: 0.1.2
       magic-string: 0.25.7
       micromatch: 4.0.4
       pirates: 4.0.1
+      recrawl: 2.2.0
       sucrase: 3.17.1
       windicss: 2.5.14
     devDependencies:
       '@antfu/ni': 0.5.7
       '@types/debug': 4.1.5
+      '@types/globrex': 0.1.0
       '@types/micromatch': 4.0.1
       '@types/node': 14.14.37
       '@types/pug': 2.0.4
@@ -742,6 +746,10 @@ packages:
       minimist: 1.2.5
     dev: true
 
+  /@cush/relative/1.0.0:
+    resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
+    dev: false
+
   /@eslint/eslintrc/0.4.0:
     resolution: {integrity: sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -990,10 +998,12 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       run-parallel: 1.2.0
+    dev: true
 
   /@nodelib/fs.stat/2.0.4:
     resolution: {integrity: sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==}
     engines: {node: '>= 8'}
+    dev: true
 
   /@nodelib/fs.walk/1.2.6:
     resolution: {integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==}
@@ -1001,6 +1011,7 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
       fastq: 1.11.0
+    dev: true
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -1073,6 +1084,10 @@ packages:
     resolution: {integrity: sha512-O9T2LLkRDiTlalOBdjEkcnT0MRdT2+wglCl7pJUJ3mkWkR8hX4K+5bg2raQNJcLv4V8zGuTXe7Ud3wSqkTyuyQ==}
     dependencies:
       '@types/node': 14.14.37
+    dev: true
+
+  /@types/globrex/0.1.0:
+    resolution: {integrity: sha512-aBkxDgp/UbnluE+CIT3V3PoNewwOlLCzXSF3ipD86Slv8xVjwxrDAfSGbsfGgMzPo/fEMPXc+gNUJbtiugwfoA==}
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -3043,6 +3058,7 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.3
       picomatch: 2.2.2
+    dev: true
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -3056,6 +3072,7 @@ packages:
     resolution: {integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==}
     dependencies:
       reusify: 1.0.4
+    dev: true
 
   /fb-watchman/2.0.1:
     resolution: {integrity: sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==}
@@ -3264,6 +3281,11 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.1
+    dev: true
+
+  /glob-regex/0.3.2:
+    resolution: {integrity: sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==}
+    dev: false
 
   /glob/7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -3312,6 +3334,10 @@ packages:
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
+
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
 
   /got/9.6.0:
     resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==}
@@ -3723,6 +3749,7 @@ packages:
   /is-extglob/2.1.1:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /is-fullwidth-code-point/2.0.0:
     resolution: {integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=}
@@ -3744,6 +3771,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+    dev: true
 
   /is-installed-globally/0.3.2:
     resolution: {integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==}
@@ -4720,6 +4748,7 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
 
   /micromatch/3.1.10:
     resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
@@ -4746,6 +4775,7 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
+    dev: true
 
   /micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
@@ -5228,6 +5258,7 @@ packages:
   /picomatch/2.2.2:
     resolution: {integrity: sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==}
     engines: {node: '>=8.6'}
+    dev: true
 
   /picomatch/2.2.3:
     resolution: {integrity: sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==}
@@ -5549,6 +5580,7 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
 
   /rc/1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -5634,6 +5666,15 @@ packages:
     dependencies:
       picomatch: 2.2.2
     dev: true
+
+  /recrawl/2.2.0:
+    resolution: {integrity: sha512-YyidjGCS0NDl7Gqdqclj3FJlojgmiLKIO26c1o9bEm9NxFmcYKrnAXwm/mNTXDOPSIbr1Ts3IyyCJJZ0HowFCQ==}
+    dependencies:
+      '@cush/relative': 1.0.0
+      glob-regex: 0.3.2
+      slash: 3.0.0
+      tslib: 1.14.1
+    dev: false
 
   /regex-not/1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
@@ -5815,6 +5856,7 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
 
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -5845,6 +5887,7 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
 
   /rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -6016,7 +6059,6 @@ packages:
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /slice-ansi/4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
@@ -6511,7 +6553,6 @@ packages:
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: true
 
   /tsup/4.8.21:
     resolution: {integrity: sha512-8paK4Q0jvsbZE7v9ptsL1JxUSs83etaml2IrNBOsnTdgrHD/gq9dvxEcWU7rNdyCCh4UhUZ8RlEjRI3etZyfsw==}


### PR DESCRIPTION
I noticed that `fast-glob` is crawling excluded directories, which slows down startup time significantly for large projects.

I've replaced `fast-glob` with [recrawl](https://www.npmjs.com/package/recrawl) and [globrex](https://www.npmjs.com/package/globrex). Recrawl does not support absolute globs, so I map `scanOptions.{include,exclude}` into their relative forms. At the same time, I use `globrex` to transform the globs into regexes. Recrawl has its own glob syntax, but regexes are also supported. With `globrex`, users get normal glob syntax.

Lastly, I've removed the `/**/*` parts from the default `exclude` globs, because those prevent Recrawl from skipping traversal of the `node_modules` and `.git` directories, which is the big performance improvement.

I consider this PR a fix, not a breaking change.