### PR TITLE
docs: update docs with add `WindiCSS.default()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import WindiCSS from 'vite-plugin-windicss'
 
 export default {
   plugins: [
-    WindiCSS()
+    WindiCSS.default()
   ],
 };
 ```


### PR DESCRIPTION
`WindiCSS.default()` is the proper method when importing WindiCSS as a plugin in vite, the examples use `WindiCSS.default()` but nothing else does