### PR TITLE
feat: Globalise keyframes

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -225,7 +225,7 @@ export function createUtils(
   }
 
   function transformCSS(css: string, id: string, transformOptions?: {
-    onLayerUpdated?: () => void,
+    onLayerUpdated?: () => void
     globaliseKeyframes?: boolean
   }) {
     if (!options.transformCSS)
@@ -233,8 +233,8 @@ export function createUtils(
     const style = new CSSParser(css, processor).parse()
     // if we should move locally scoped keyframes to the global stylesheet, avoids possible duplicates
     if (transformOptions?.globaliseKeyframes) {
-      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children,
-              i => !i.atRules || !i.atRules[0].match(/keyframes (pulse|spin|ping|bounce)/)
+      const [nonKeyframeBlocks, keyframeBlocks] = partition(style.children,
+        i => !i.atRules || !i.atRules[0].match(/keyframes (pulse|spin|ping|bounce)/),
       )
       // register the keyframe blocks to our global classes
       updateLayers(keyframeBlocks, '__classes', false)

--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -224,10 +224,21 @@ export function createUtils(
     return changed
   }
 
-  function transformCSS(css: string, id: string, transformOptions?: { onLayerUpdated?: () => void }) {
+  function transformCSS(css: string, id: string, transformOptions?: {
+    onLayerUpdated?: () => void,
+    globaliseKeyframes?: boolean
+  }) {
     if (!options.transformCSS)
       return css
     const style = new CSSParser(css, processor).parse()
+    // if we should move locally scoped keyframes to the global stylesheet, avoids possible duplicates
+    if (transformOptions?.globaliseKeyframes) {
+      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children, i => !i.atRules || i.atRules[0].indexOf('keyframes ') === -1)
+      // register the keyframe blocks to our global classes
+      updateLayers(keyframeBlocks, '__classes', false)
+      // set the children without the keyframes
+      style.children = nonKeyframeBlocks
+    }
     const [layerBlocks, blocks] = partition(style.children, i => i.meta.group === 'layer-block' && SupportedLayers.includes(i.meta.type))
     if (layerBlocks.length) {
       updateLayers(layerBlocks, id)

--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -233,10 +233,9 @@ export function createUtils(
     const style = new CSSParser(css, processor).parse()
     // if we should move locally scoped keyframes to the global stylesheet, avoids possible duplicates
     if (transformOptions?.globaliseKeyframes) {
-      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children, i => {
-        console.log(i)
-        return !i.atRules || i.atRules[0].indexOf('keyframes ') === -1
-      })
+      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children,
+              i => !i.atRules || !i.atRules[0].match(/keyframes (pulse|spin|ping|bounce)/)
+      )
       // register the keyframe blocks to our global classes
       updateLayers(keyframeBlocks, '__classes', false)
       // set the children without the keyframes

--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -233,7 +233,10 @@ export function createUtils(
     const style = new CSSParser(css, processor).parse()
     // if we should move locally scoped keyframes to the global stylesheet, avoids possible duplicates
     if (transformOptions?.globaliseKeyframes) {
-      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children, i => !i.atRules || i.atRules[0].indexOf('keyframes ') === -1)
+      const [ nonKeyframeBlocks, keyframeBlocks ] = partition(style.children, i => {
+        console.log(i)
+        return !i.atRules || i.atRules[0].indexOf('keyframes ') === -1
+      })
       // register the keyframe blocks to our global classes
       updateLayers(keyframeBlocks, '__classes', false)
       // set the children without the keyframes

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -117,6 +117,47 @@ exports[`transfrom css directives: basic @layer 1`] = `
 }"
 `;
 
+exports[`transfrom css keyframes 1`] = `
+"/* windicss layer base */
+
+/* windicss layer components */
+
+/* windicss layer utilities */"
+`;
+
+exports[`transfrom css keyframes: keyframe module 1`] = `
+"/* windicss layer base */
+
+/* windicss layer components */
+@keyframes pulse {
+  .pulse-class {
+    opacity: 1;
+    opacity: .5;
+  }
+}
+@-webkit-keyframes pulse {
+  .pulse-class {
+    opacity: 1;
+    opacity: .5;
+  }
+}
+/* windicss layer utilities */"
+`;
+
+exports[`transfrom css keyframes: keyframes 1`] = `
+".pulse-class {
+  --tw-bg-opacity: 1;
+  background-color: rgba(13, 148, 136, var(--tw-bg-opacity));
+  border-radius: 9999px;
+  height: 10rem;
+  opacity: 0.8;
+  position: relative;
+  width: 10rem;
+  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}"
+`;
+
 exports[`transfrom groups: "!hover:(m-2 p-2)" 1`] = `"!hover:m-2 !hover:p-2"`;
 
 exports[`transfrom groups: "+sm:(p-1 p-2)" 1`] = `"+sm:p-1 +sm:p-2"`;

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transfrom css custom keyframes 1`] = `
+"/* windicss layer base */
+
+/* windicss layer components */
+
+/* windicss layer utilities */"
+`;
+
+exports[`transfrom css custom keyframes: keyframes 1`] = `
+".test {
+  animation: my-animation 2s infinite linear;
+}
+@keyframes my-animation {
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}"
+`;
+
+exports[`transfrom css custom keyframes: keyframes module 1`] = `
+"/* windicss layer base */
+
+/* windicss layer components */
+
+/* windicss layer utilities */"
+`;
+
 exports[`transfrom css directives 1`] = `
 "/* windicss layer base */
 
@@ -117,7 +144,7 @@ exports[`transfrom css directives: basic @layer 1`] = `
 }"
 `;
 
-exports[`transfrom css keyframes 1`] = `
+exports[`transfrom css windi keyframes 1`] = `
 "/* windicss layer base */
 
 /* windicss layer components */
@@ -125,7 +152,21 @@ exports[`transfrom css keyframes 1`] = `
 /* windicss layer utilities */"
 `;
 
-exports[`transfrom css keyframes: keyframe module 1`] = `
+exports[`transfrom css windi keyframes: keyframes 1`] = `
+".pulse-class {
+  --tw-bg-opacity: 1;
+  background-color: rgba(13, 148, 136, var(--tw-bg-opacity));
+  border-radius: 9999px;
+  height: 10rem;
+  opacity: 0.8;
+  position: relative;
+  width: 10rem;
+  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}"
+`;
+
+exports[`transfrom css windi keyframes: keyframes module 1`] = `
 "/* windicss layer base */
 
 /* windicss layer components */
@@ -142,20 +183,6 @@ exports[`transfrom css keyframes: keyframe module 1`] = `
   }
 }
 /* windicss layer utilities */"
-`;
-
-exports[`transfrom css keyframes: keyframes 1`] = `
-".pulse-class {
-  --tw-bg-opacity: 1;
-  background-color: rgba(13, 148, 136, var(--tw-bg-opacity));
-  border-radius: 9999px;
-  height: 10rem;
-  opacity: 0.8;
-  position: relative;
-  width: 10rem;
-  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}"
 `;
 
 exports[`transfrom groups: "!hover:(m-2 p-2)" 1`] = `"!hover:m-2 !hover:p-2"`;

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -93,4 +93,31 @@ describe('transfrom', () => {
     expect(components).toMatchSnapshot('@layer components')
     expect(await utils.generateCSS('utilities')).toMatchSnapshot('@layer utilities')
   })
+  it('css keyframes', async() => {
+    const utils = createUtils({
+      preflight: false,
+      scan: false,
+    })
+
+    await utils.init()
+
+    expect(await utils.generateCSS()).toMatchSnapshot()
+
+    const css = `
+      .pulse-class {
+         @apply relative w-40 h-40 rounded-full bg-teal-600 opacity-80 animate-pulse;
+      }
+    `
+
+    await utils.extractFile(css, 'group0', true)
+
+    const transformed = utils.transformCSS(css, 'group0', { globalKeyframes: true })
+
+    expect(transformed).not.toContain('@keyframe')
+    expect(transformed).toMatchSnapshot('keyframes')
+
+    const moduleCSS = await utils.generateCSS()
+    expect(moduleCSS).toContain('@keyframe')
+    expect(moduleCSS).toMatchSnapshot('keyframe module')
+  })
 })

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -93,7 +93,7 @@ describe('transfrom', () => {
     expect(components).toMatchSnapshot('@layer components')
     expect(await utils.generateCSS('utilities')).toMatchSnapshot('@layer utilities')
   })
-  it('css keyframes', async() => {
+  it('css windi keyframes', async() => {
     const utils = createUtils({
       preflight: false,
       scan: false,
@@ -113,11 +113,43 @@ describe('transfrom', () => {
 
     const transformed = utils.transformCSS(css, 'group0', { globaliseKeyframes: true })
 
-    expect(transformed).not.toContain('@keyframe')
+    expect(transformed).not.toContain('@keyframes')
     expect(transformed).toMatchSnapshot('keyframes')
 
     const moduleCSS = await utils.generateCSS()
-    expect(moduleCSS).toContain('@keyframe')
-    expect(moduleCSS).toMatchSnapshot('keyframe module')
+    expect(moduleCSS).toContain('@keyframes')
+    expect(moduleCSS).toMatchSnapshot('keyframes module')
+  })
+  it('css custom keyframes', async() => {
+    const utils = createUtils({
+      preflight: false,
+      scan: false,
+    })
+
+    await utils.init()
+
+    expect(await utils.generateCSS()).toMatchSnapshot()
+
+    const css = `
+      .test {
+        animation: my-animation 2s infinite linear;
+      }
+      @keyframes my-animation {
+        100% {
+          -webkit-transform: rotate(360deg);
+        }
+      }
+    `
+
+    await utils.extractFile(css, 'group0', true)
+
+    const transformed = utils.transformCSS(css, 'group0', { globaliseKeyframes: true })
+
+    expect(transformed).toContain('@keyframes')
+    expect(transformed).toMatchSnapshot('keyframes')
+
+    const moduleCSS = await utils.generateCSS()
+    expect(moduleCSS).not.toContain('@keyframes')
+    expect(moduleCSS).toMatchSnapshot('keyframes module')
   })
 })

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -111,7 +111,7 @@ describe('transfrom', () => {
 
     await utils.extractFile(css, 'group0', true)
 
-    const transformed = utils.transformCSS(css, 'group0', { globalKeyframes: true })
+    const transformed = utils.transformCSS(css, 'group0', { globaliseKeyframes: true })
 
     expect(transformed).not.toContain('@keyframe')
     expect(transformed).toMatchSnapshot('keyframes')


### PR DESCRIPTION
When you have scoped styles within Vue, and you use windi animations as:

```
.pulse-class {
         @apply relative w-40 h-40 rounded-full bg-teal-600 opacity-80 animate-pulse;
      }
```

It will add the keyframe to the transformed css. This leads to duplicates and another vue specific issue around the scope ids and not transforming the keyframes.

Fixes https://github.com/windicss/windicss/issues/212