### PR TITLE
fix: #177

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -266,7 +266,7 @@ export function createUtils(
     }
     else {
       const prevStyles = layerStylesMap.get(filepath) || []
-      layerStylesMap.set(filepath, styles.concat(prevStyles))
+      layerStylesMap.set(filepath, prevStyles.concat(styles))
     }
 
     for (const name of changedLayers) {

--- a/packages/plugin-utils/src/resolveOptions.ts
+++ b/packages/plugin-utils/src/resolveOptions.ts
@@ -7,7 +7,7 @@ import { defaultAlias, defaultConfigureFiles } from './constants'
 import { Arrayable, kebabCase, mergeArrays, slash, toArray } from './utils'
 import { getDefaultExtractors } from './extractors/helper'
 
-const jiti = _jiti(__filename, { cache: false })
+const jiti = _jiti(__filename, { cache: false, requireCache: false })
 
 export function isResolvedOptions(options: UserOptions | ResolvedOptions): options is ResolvedOptions {
   // @ts-expect-error internal flag


### PR DESCRIPTION
There are two problems in this case:
1. `jiti` will load cache from require, this will cause the configuration file to be loaded as the old configuration.

https://github.com/unjs/jiti/blob/2062b36292908f7b4324be3bfc8d02f4f96dd83d/src/jiti.ts#L166-L168

2. the new style should overwrite the old style

I fix it to `next` branch, if you want to fix it to `main`, plz tell me.