### PR TITLE
fix: jiti load cache from require

### DIFF
--- a/packages/plugin-utils/src/resolveOptions.ts
+++ b/packages/plugin-utils/src/resolveOptions.ts
@@ -7,7 +7,7 @@ import { defaultAlias, defaultConfigureFiles } from './constants'
 import { Arrayable, kebabCase, mergeArrays, slash, toArray } from './utils'
 import { getDefaultExtractors } from './extractors/helper'
 
-const jiti = _jiti(__filename, { cache: false })
+const jiti = _jiti(__filename, { requireCache: false, cache: false })
 
 export function isResolvedOptions(options: UserOptions | ResolvedOptions): options is ResolvedOptions {
   // @ts-expect-error internal flag


### PR DESCRIPTION
jiti will load cache from require, this will cause the configuration file to be loaded as the old configuration.

https://github.com/unjs/jiti/blob/2062b36292908f7b4324be3bfc8d02f4f96dd83d/src/jiti.ts#L166-L168