### PR TITLE
fix: support pcss as a CSS transform target

### DIFF
--- a/packages/plugin-utils/src/createUtils.ts
+++ b/packages/plugin-utils/src/createUtils.ts
@@ -143,7 +143,7 @@ export function createUtils(
   function isCssTransformTarget(id: string) {
     if (options.scanOptions.extraTransformTargets.css.some(i => typeof i === 'string' ? i === id : i(id)))
       return true
-    if (id.match(/\.(?:postcss|scss|sass|css|stylus|less)(?:$|\?)/i) && !isExcluded(id))
+    if (id.match(/\.(?:postcss|pcss|scss|sass|css|stylus|less)(?:$|\?)/i) && !isExcluded(id))
       return true
     return false
   }


### PR DESCRIPTION
We added it as a scan target but we aren't transforming it at the moment, this fixes that.

Identified it as the issue when debugging this issue https://github.com/windicss/nuxt-windicss-module/issues/95