### PR TITLE
feat: move sveltePreprocess to api namespace

### DIFF
--- a/packages/vite-plugin-windicss/src/index.ts
+++ b/packages/vite-plugin-windicss/src/index.ts
@@ -200,12 +200,13 @@ function VitePluginWindicss(userOptions: UserOptions = {}, utilsOptions: WindiPl
 
   plugins.push({
     name: `${NAME}:css:svelte`,
-    // @ts-expect-error for svelte preprocess
-    sveltePreprocess: {
-      style({ content, id }: { content: string; id: string}) {
-        return {
-          code: transformCSS(content, id),
-        }
+    api: {
+      sveltePreprocess: {
+        style({ content, id }: { content: string; id: string}) {
+          return {
+            code: transformCSS(content, id),
+          }
+        },
       },
     },
   })


### PR DESCRIPTION
as suggested by [rollup](https://rollupjs.org/guide/en/#direct-plugin-communication), vite-plugin-svelte moved the location it searches for additional preprocessors to the api namespace:

see https://github.com/sveltejs/vite-plugin-svelte/blob/main/packages/vite-plugin-svelte/CHANGELOG.md

This PR updates vite-plugin-windicss to use it.