### PR TITLE
fix: Ensure the root option provided by the user has higher priority (close #214)

### DIFF
--- a/packages/plugin-utils/src/resolveOptions.ts
+++ b/packages/plugin-utils/src/resolveOptions.ts
@@ -47,12 +47,14 @@ export async function resolveOptions(
 
   const debugOptions = _debug(`${name}:options`)
 
+  const root = options.root || utilsOptions.root || process.cwd()
+
   // eslint-disable-next-line prefer-const
   let { config, filepath: configFilePath } = loadConfigFile
     ? loadConfiguration({
       onConfigurationError: error => console.error(error),
       ...utilsOptions,
-      root: options.root || utilsOptions.root,
+      root,
       config: options.config,
       configFiles: options.configFiles,
     })
@@ -64,7 +66,6 @@ export async function resolveOptions(
     config = modifiedConfigs
 
   const {
-    root = utilsOptions.root || process.cwd(),
     scan = true,
     preflight = true,
     transformCSS = true,

--- a/packages/plugin-utils/src/resolveOptions.ts
+++ b/packages/plugin-utils/src/resolveOptions.ts
@@ -52,7 +52,7 @@ export async function resolveOptions(
     ? loadConfiguration({
       onConfigurationError: error => console.error(error),
       ...utilsOptions,
-      root: utilsOptions.root || options.root,
+      root: options.root || utilsOptions.root,
       config: options.config,
       configFiles: options.configFiles,
     })


### PR DESCRIPTION
### Description 📖 

This pull request ensures that when users provide the `root` option, it's used consistently when loading configuration files.

### Background 📜 

The `root` user option was [introduced for projects where Vite's root does not match the project root](https://github.com/windicss/vite-plugin-windicss/blob/8b739620b651b5c0e043165e04d266e973be2b2c/packages/plugin-utils/src/createUtils.ts#L28), allowing files to be resolved correctly.

When the `windi.config.ts` file was introduced, files [were correctly resolved using the user provided root](https://github.com/windicss/vite-plugin-windicss/pull/110/files#diff-7cce94c31d7e1a4a6328850ea2b8a8a01a9053ccbbb07bd67617ecebec403befR55-R60).

In #129, the precedence was accidentally inverted when loading configuration files, which means configuration files would be resolved against the Vite root instead (see the first problem described in https://github.com/windicss/vite-plugin-windicss/issues/214).