### PR TITLE
fix(rollup): respect default for `transformCSS` option in Rollup plugin

### DIFF
--- a/packages/rollup-plugin-windicss/src/index.ts
+++ b/packages/rollup-plugin-windicss/src/index.ts
@@ -54,7 +54,7 @@ function WindiCssRollupPlugin(userOptions: UserOptions = {}): Plugin[] {
     ...createVirtualModuleLoader({ utils }),
   })
 
-  if (userOptions.transformCSS != null) {
+  if (userOptions.transformCSS !== false) {
     plugins.push({
       name: `${NAME}:css`,
       async transform(code, id) {


### PR DESCRIPTION
Previously if the user didn't set the `transformCSS` option explicitly then it would be disabled since `undefined == null`. However, [it should be enabled by default](https://github.com/windicss/vite-plugin-windicss/blob/v1.3.0/packages/plugin-utils/src/options.ts#L157-L162) so this behaviour is incorrect. I have changed it to perform the same check as in `transformGroups` whereby it is enabled unless explicitly set to `false`.