### PR TITLE
fix: add `exports` field, resolve #90

### DIFF
--- a/packages/vite-plugin-windicss/package.json
+++ b/packages/vite-plugin-windicss/package.json
@@ -43,5 +43,11 @@
     "@types/node": "^16.9.6",
     "tsup": "^5.1.0",
     "vite": "^2.5.10"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
   }
 }


### PR DESCRIPTION
- fixes WindiCSS is not a function when type module is set in
package.json, also fixes TypeScript import errors for other workarounds
suggested in #90. Code from
https://github.com/windicss/vite-plugin-windicss/issues/90#issuecomment-891747631