### PR TITLE
fix(vite): makes devtools esm compatible, close #241

### DIFF
--- a/packages/vite-plugin-windicss/src/devtools.ts
+++ b/packages/vite-plugin-windicss/src/devtools.ts
@@ -1,11 +1,14 @@
 import fs from 'fs'
-import path from 'path'
+import path, { dirname } from 'path'
+import { fileURLToPath } from 'url'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import type { WindiPluginUtils } from '@windicss/plugin-utils'
 import type { IncomingMessage } from 'connect'
 import _debug from 'debug'
 import { NAME } from './constants'
 import { getChangedModuleNames, getCssModules, invalidateCssModules, sendHmrReload } from './modules'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const debug = {
   devtools: _debug(`${NAME}:devtools`),

--- a/packages/vite-plugin-windicss/src/devtools.ts
+++ b/packages/vite-plugin-windicss/src/devtools.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import path, { dirname } from 'path'
+import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import type { WindiPluginUtils } from '@windicss/plugin-utils'
@@ -8,7 +8,9 @@ import _debug from 'debug'
 import { NAME } from './constants'
 import { getChangedModuleNames, getCssModules, invalidateCssModules, sendHmrReload } from './modules'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const _dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url))
 
 const debug = {
   devtools: _debug(`${NAME}:devtools`),
@@ -121,7 +123,7 @@ document.head.prepend(style)
         if (id === DEVTOOLS_PATH) {
           if (!clientCode) {
             clientCode = [
-              await fs.promises.readFile(path.resolve(__dirname, 'client.mjs'), 'utf-8'),
+              await fs.promises.readFile(resolve(_dirname, 'client.mjs'), 'utf-8'),
               `import('${MOCK_CLASSES_MODULE_ID}')`,
             ]
               .join('\n')


### PR DESCRIPTION
Fixes #241: By addressing reference to deprecated global variable __dirname as per node's [recommendation](https://nodejs.org/api/esm.html#esm_no_filename_or_dirname).

While the `lint`, `test` and `build` command ran fine after these changes. `test:examples` blew up. Not sure why. It does not seem to be due to the changes created by this PR.