### PR TITLE
bump windicss to 3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.4.8",
+  "version": "1.4.9",
   "keywords": [
     "vite",
     "vite-plugin",
@@ -48,6 +48,6 @@
     "typescript": "^4.4.3",
     "vite": "^2.5.10",
     "vite-plugin-restart": "^0.0.2",
-    "windicss": "^3.1.7"
+    "windicss": "^3.1.8"
   }
 }


### PR DESCRIPTION
This bumps windicss to [3.1.8](https://github.com/windicss/windicss/releases/tag/v3.1.8) which includes an important bugfix for [daisyUI](https://github.com/windicss/windicss/issues/439)