### PR TITLE
feat(devtools): support custom backends

### DIFF
--- a/packages/vite-plugin-windicss/src/devtools.ts
+++ b/packages/vite-plugin-windicss/src/devtools.ts
@@ -127,7 +127,7 @@ document.head.prepend(style)
               `import('${MOCK_CLASSES_MODULE_ID}')`,
             ]
               .join('\n')
-              .replace('__POST_PATH__', POST_PATH)
+              .replace('__POST_PATH__', (config.server?.origin ?? '') + POST_PATH)
           }
           return config.command === 'build'
             ? ''


### PR DESCRIPTION
This PR brings support for using devtools with a custom back-end. 

The summary is in this PR: https://github.com/vitejs/vite/pull/5104, but basically the only change is to prefix the `POST_PATH` injected to the client script with the configured server origin, if there is one. 

**Note**: I monkey-patched that locally and made the change directly via GitHub since it's simple enough, but please make sure I didn't break it for normal use cases before merging. Thanks!