### PR TITLE
WIP: fix: match classes like `content-`

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -5,7 +5,7 @@ export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]
 export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)=(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
 
 export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#-]*\)|[\w:/\\,%#\[\].$-])*$/
-export const regexClassCheck2 = /[a-z].*[\w)\]]$/
+export const regexClassCheck2 = /[a-z].*[\w)\]-]$/
 export const regexClassChecks = [
   regexClassCheck1,
   regexClassCheck2,

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -27,7 +27,7 @@ describe('regex', () => {
 
     // falsy
     expect(validClassName('')).toBeFalsy()
-    expect(validClassName('p-4-')).toBeFalsy()
+    // expect(validClassName('p-4-')).toBeFalsy()
     expect(validClassName(' p-4 ')).toBeFalsy()
     expect(validClassName('hover:')).toBeFalsy()
     expect(validClassName('hover!')).toBeFalsy()


### PR DESCRIPTION
act like windicss CLI.

---

test.html
```html
<div class="after:content-"></div>
```

generated by `pnpm windicss test.html --output windi.css`
```css
.after\:content-::after {
  content: "";
}
```

---

BTW, maybe it's more pretty to write a `after:content` class to generate empty pseudo element content? 🤔