### PR TITLE
fix: mismatch includes '+()'

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -4,7 +4,7 @@ export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
 export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)=(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
 
-export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#-]*\)|[\w:/\\,%#\[\].$-])*$/
+export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#\(\)+-]*\)|[\w:/\\,%#\[\].$-])*$/
 export const regexClassCheck2 = /[a-z].*[\w)\]]$/
 export const regexClassChecks = [
   regexClassCheck1,

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -24,6 +24,7 @@ describe('regex', () => {
     expect(validClassName('!+sm:w-full')).toBeTruthy()
     expect(validClassName('!-sm:w-full')).toBeTruthy()
     expect(validClassName('!@sm:w-full')).toBeTruthy()
+    expect(validClassName('p-[calc(10px+12rem)]')).toBeTruthy()
 
     // falsy
     expect(validClassName('')).toBeFalsy()


### PR DESCRIPTION
fix mismatch includes '+()'.
Eg:
```html
<div class="h-[calc(var(--box-size)+20rem)]">Hello</div>
```