### PR TITLE
Added no-cors mode to fetch call

### DIFF
--- a/packages/vite-plugin-windicss/src/client.ts
+++ b/packages/vite-plugin-windicss/src/client.ts
@@ -4,6 +4,7 @@
 function post(data: any) {
   return fetch('__POST_PATH__', {
     method: 'POST',
+    mode: 'no-cors',
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
As I mentioned in #250, I prefer to use real domains instead of something like `http://localhost:3000` when developing. This led to a CORS issue, tho, when using the devtools. This pull request disables CORS for the request. Devtools are only used locally, so this change shouldn't impact security, I guess. Adding this option means that the response cannot be read, but this doesn't seem to be the case anyways.

More info here: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode 