### PR TITLE
fix: support for whitespace in attribute/value pair

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -2,7 +2,7 @@ export const regexQuotedString = /(["'`])((?:\\\1|\\\\|\n|\r|(?!<|>|\s\*\/).)*?)
 export const regexHtmlTag = /<(\w[\w-]*)([\S\s]*?)\/?>/mg
 export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
-export const regexAttributifyItem = /(?:\s|^)([\w+:_\/-]+)\s?=\s?(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
+export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)\s?=\s?(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
 
 export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#\(\)+-]*\)|[\w:/\\,%#\[\].$-])*$/
 export const regexClassCheck2 = /[a-z].*[\w)\]]$/

--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -2,7 +2,7 @@ export const regexQuotedString = /(["'`])((?:\\\1|\\\\|\n|\r|(?!<|>|\s\*\/).)*?)
 export const regexHtmlTag = /<(\w[\w-]*)([\S\s]*?)\/?>/mg
 export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
-export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)=(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
+export const regexAttributifyItem = /(?:\s|^)([\w+:_\/-]+)\s?=\s?(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
 
 export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#\(\)+-]*\)|[\w:/\\,%#\[\].$-])*$/
 export const regexClassCheck2 = /[a-z].*[\w)\]]$/


### PR DESCRIPTION
Should fix https://github.com/windicss/vite-plugin-windicss/issues/256

Simply changed `regexAttributifyItem` to detect the attributes even when there's a space between `key` and `value` like: `h = "20"`. Did this by adding optional whitespace matching before and after the `=` using `\s?=\s?`.