### PR TITLE
Fix tag extraction for React projects

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -1,5 +1,5 @@
 export const regexQuotedString = /(["'`])((?:\\\1|\\\\|\n|\r|(?!<|>|\s\*\/).)*?)\1/mg
-export const regexHtmlTag = /<(\w[\w-]*)([\S\s]*?)\/?>/mg
+export const regexHtmlTag = /<(\w[\w-]*)([\S\s]*?)\/?[^=]>/mg
 export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
 export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)\s?=\s?(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm


### PR DESCRIPTION
WindiCSS (with React + Vite), was failing to detect my attributes in the following code:

```jsx
<input
  onChange = {event => props.model[1](props.model[0], event.target.value)}
  type = {inputData.toggle ? 'text' : props.type}
  value = {props.data}
  w-bg = "white dark:black"
  w-border = {borderStyle()}
  w-font = "leading-none"
  w-h = "10"
  w-outline = "none"
  w-p = {props.type === 'password' ? 'l-10 r-17.5' : 'x-10' + ' y-2'}
  w-w = "full"/>
```

When I checked, it seemed to be failing at this line: https://github.com/windicss/vite-plugin-windicss/blob/main/packages/plugin-utils/src/extractors/default.ts#L12

The current regex here: https://github.com/windicss/vite-plugin-windicss/blob/main/packages/plugin-utils/src/regexes.ts#L2 stops detecting at:

```jsx
<input
  onChange = {event =>
```

So, it has been modified to ignore the `=`.