### PR TITLE
fix: support multiple whitespace in attribute/value pair

### DIFF
--- a/packages/plugin-utils/src/regexes.ts
+++ b/packages/plugin-utils/src/regexes.ts
@@ -2,7 +2,7 @@ export const regexQuotedString = /(["'`])((?:\\\1|\\\\|\n|\r|(?!<|>|\s\*\/).)*?)
 export const regexHtmlTag = /<(\w[\w-]*)([\S\s]*?)\/?>/mg
 export const regexClassSplitter = /[\s'"`{}]/g
 export const regexClassGroup = /([!\w+-<@][\w+:_/-]*?\w):\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
-export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)\s?=\s?(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
+export const regexAttributifyItem = /(?:\s|^)([\w+:_/-]+)\s*=\s*(['"{])((?:\\\2|\\\\|\n|\r|.)*?)(?:\2|\})/gm
 
 export const regexClassCheck1 = /^!?[a-z\d@<>.+-](?:\([\w,.%#\(\)+-]*\)|[\w:/\\,%#\[\].$-])*$/
 export const regexClassCheck2 = /[a-z].*[\w)\]]$/


### PR DESCRIPTION
The vertically-aligned attributes
```
  bg     = "blue-400 hover:blue-500 dark:blue-500 dark:hover:blue-600"
  text   = "sm white"
  font   = "mono light"
  p      = "y-2 x-4"
  border = "2 rounded blue-200"
```
are much more readable vs the non-vertically-aligned
```
  bg="blue-400 hover:blue-500 dark:blue-500 dark:hover:blue-600"
  text="sm white"
  font="mono light"
  p="y-2 x-4"
  border="2 rounded blue-200"
```

fix #256