### PR TITLE
fix: allow matching virtual id with query parameters

### DIFF
--- a/packages/shared/virtual-module.ts
+++ b/packages/shared/virtual-module.ts
@@ -15,6 +15,9 @@ export const MODULE_ID_VIRTUAL_MODULES = [
 export function createVirtualModuleLoader(ctx: { utils: WindiPluginUtils }): Pick<Plugin, 'resolveId' | 'load' | 'watchChange'> {
   return {
     resolveId(id) {
+      if (id.startsWith(MODULE_ID_VIRTUAL_PREFIX)) {
+        return id
+      }
       for (const idRegex of MODULE_IDS) {
         const match = id.match(idRegex)
         if (match)


### PR DESCRIPTION
resolves https://github.com/windicss/nuxt-windicss/issues/180

context: https://github.com/nuxt/framework/issues/7372