### PR TITLE
fix: The "path" argument must be of type string or an instance of URL. Received undefined

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "ESNext",
-    "target": "es2017",
+    "target": "ESNext",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45410431/207214702-538a950a-dd35-48ac-a4dc-67be882a570d.png)

An error occurs using Vite4 pnpm dev

![image](https://user-images.githubusercontent.com/45410431/207226005-e5841e9a-ee43-4390-afdd-70b8155b098b.png)

`tsup`从`v6.4.0`开始默认从`tsconfig.json`读取配置，因为现在`target`的配置为`es2017`，所以导致`import.meta`不支持，打包会生成`import_meta.url`