### PR TITLE
feat: search for *.config.mts as config file

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,16 +11,19 @@ export type { WindiCssOptions }
 
 export const defaultConfigureFiles = [
   'windi.config.ts',
+  'windi.config.mts',
   'windi.config.js',
   'windi.config.mjs',
   'windi.config.cjs',
 
   'windicss.config.ts',
+  'windicss.config.mts',
   'windicss.config.js',
   'windicss.config.mjs',
   'windicss.config.cjs',
 
   'tailwind.config.ts',
+  'tailwind.config.mts',
   'tailwind.config.js',
   'tailwind.config.mjs',
   'tailwind.config.cjs',


### PR DESCRIPTION
Along with https://github.com/unjs/jiti/pull/112 this allows us to use `.mts` files for configuring windicss. 

This fixes a problem where I needed to import from a ESM-only library in my `windi.config.js`.