### PR TITLE
fix: include types in package.json `exports`

### DIFF
--- a/packages/vite-plugin-windicss/package.json
+++ b/packages/vite-plugin-windicss/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },


### PR DESCRIPTION
This fixes this typescript error, when one tries to `import windiCSS from 'vite-plugin-windicss';`: 

```
Could not find a declaration file for module 'vite-plugin-windicss'. 
  '/project/node_modules/vite-plugin-windicss/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/project/node_modules/vite-plugin-windicss/dist/index.d.ts', but this 
  result could not be resolved when respecting package.json "exports". 
  The 'vite-plugin-windicss' library may need to update its package.json or typings.ts(7016)
```

This happens with vite-plugin-windicss v1.9.0, typescript v5.1.6 and the `moduleResolution` tsconfig compiler-option set to `bundler`, which per my understanding makes typescript import stuff only from what's defined in a module's `exports`.