### PR TITLE
fix(vite-plugin-windicss): fix vite5 hmr

### DIFF
--- a/packages/shared/virtual-module.ts
+++ b/packages/shared/virtual-module.ts
@@ -40,7 +40,7 @@ export function createVirtualModuleLoader(ctx: { utils: WindiPluginUtils; inHmr?
     },
 
     async watchChange(id, change) {
-      // In vite5, `watchChange` is triggered before hmr even if it's started, which can cause hot updates to fail，Add `inHmr` flag to skip duplicate triggers (isomorphic to vite4)
+      // In vite5, watchChange is triggered before hmr even if the devServer is started, which causes the hot update to fail, add the inHmr flag to skip the repeat trigger (as in vite4)
       if (ctx.inHmr)
         return
 

--- a/packages/shared/virtual-module.ts
+++ b/packages/shared/virtual-module.ts
@@ -12,7 +12,7 @@ export const MODULE_ID_VIRTUAL_MODULES = [
   `${MODULE_ID_VIRTUAL_PREFIX}-components.css`,
 ]
 
-export function createVirtualModuleLoader(ctx: { utils: WindiPluginUtils }): Pick<Plugin, 'resolveId' | 'load' | 'watchChange'> {
+export function createVirtualModuleLoader(ctx: { utils: WindiPluginUtils; inHmr?: boolean }): Pick<Plugin, 'resolveId' | 'load' | 'watchChange'> {
   return {
     resolveId(id) {
       if (id.startsWith(MODULE_ID_VIRTUAL_PREFIX))
@@ -40,6 +40,10 @@ export function createVirtualModuleLoader(ctx: { utils: WindiPluginUtils }): Pic
     },
 
     async watchChange(id, change) {
+      // In vite5, `watchChange` is triggered before hmr even if it's started, which can cause hot updates to fail，Add `inHmr` flag to skip duplicate triggers (isomorphic to vite4)
+      if (ctx.inHmr)
+        return
+
       if (change.event === 'delete' || !existsSync(id))
         return
       if (!ctx.utils.isDetectTarget(id))

--- a/packages/vite-plugin-windicss/package.json
+++ b/packages/vite-plugin-windicss/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0"
+    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@windicss/plugin-utils": "workspace:*",

--- a/packages/vite-plugin-windicss/src/index.ts
+++ b/packages/vite-plugin-windicss/src/index.ts
@@ -91,7 +91,12 @@ function VitePluginWindicss(userOptions: UserOptions = {}, utilsOptions: WindiPl
       await utils.ensureInit()
     },
 
-    ...createVirtualModuleLoader({ get utils() { return utils } }) as Omit<Plugin, 'name'>,
+    ...createVirtualModuleLoader({
+      get utils() { return utils },
+      get inHmr() {
+        return Boolean(server)
+      },
+    }) as Omit<Plugin, 'name'>,
   })
 
   let _cssReloadTask: any


### PR DESCRIPTION
In vite5, `watchChange` is triggered before `hmr` even if the `devServer` is started, which causes the hot update to fail, add the `inHmr` flag to skip the repeat trigger (as in vite4)

I simply tested vite4 and vite5 in the local area, and now their HMR works well.
If there is any case, I was ignored, please tell me. 🤣

Maybe there are stricter restrictions here, even specific to the vite version