### PR TITLE
fix(vite-plugin-windicss): Compatible with vite6

### DIFF
--- a/packages/vite-plugin-windicss/package.json
+++ b/packages/vite-plugin-windicss/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"  
+    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "@windicss/plugin-utils": "workspace:*",

--- a/packages/vite-plugin-windicss/package.json
+++ b/packages/vite-plugin-windicss/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "vite": "^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"  
   },
   "dependencies": {
     "@windicss/plugin-utils": "workspace:*",


### PR DESCRIPTION
I'm using vite-plugin-windicss under vite6 in my company's project, and it's performing well without any compatibility-breaking updates!  